### PR TITLE
Moves Gem date to VaingloryAPI::RELEASE_DATE

### DIFF
--- a/lib/vainglory_api/version.rb
+++ b/lib/vainglory_api/version.rb
@@ -1,4 +1,7 @@
 module VaingloryAPI
   # Current gem version
   VERSION = '0.0.4'.freeze
+
+  # Release date of current version
+  RELEASE_DATE = '2017-06-13'.freeze
 end

--- a/vainglory_api.gemspec
+++ b/vainglory_api.gemspec
@@ -4,8 +4,8 @@ require 'vainglory_api/version'
 Gem::Specification.new do |s|
   s.name        = 'vainglory-api'
   s.version     = VaingloryAPI::VERSION.dup
+  s.date        = VaingloryAPI::RELEASE_DATE.dup
   s.platform    = Gem::Platform::RUBY
-  s.date        = '2017-06-13'
   s.summary     = 'Vainglory API'
   s.description = 'A Ruby libary wrapper for the Vainglory API'
   s.authors     = ['Chet Bortz']


### PR DESCRIPTION
I keep forgetting to change the date when bumping the current version, so I am putting it in my face every time I go to change it!