### PR TITLE
Adds RSpec example group helpers for all lib specs

### DIFF
--- a/spec/lib/vainglory_api/client_spec.rb
+++ b/spec/lib/vainglory_api/client_spec.rb
@@ -1,16 +1,15 @@
 require 'spec_helper'
 
 describe VaingloryAPI::Client, vcr: true do
-  subject(:klass) { Object.const_get(self.class.top_level_description) }
   let(:valid_api_key) { 'valid_api_key' }
-  let(:client) { klass.new(valid_api_key) }
+  let(:client) { subject.new(valid_api_key) }
   let(:cached_matches) { let_cassette('matches') { client.matches } }
   let(:cached_players) { cached_matches.included.select { |i| i.type == 'player' }}
 
   context 'metadata' do
     it 'returns an error with an invalid API key' do
       VCR.use_cassette('api_key', record: :new_episodes) do
-        response = klass.new('invalid-api-key').samples
+        response = subject.new('invalid-api-key').samples
         expects_error_response(response, 401)
       end
     end
@@ -30,7 +29,7 @@ describe VaingloryAPI::Client, vcr: true do
     it 'supports multiple regions' do
       VCR.use_cassette('samples', record: :new_episodes) do
         %w(eu sa ea sg).each do |region|
-          response = klass.new(valid_api_key, region).samples
+          response = subject.new(valid_api_key, region).samples
           expects_success_response(response)
         end
       end

--- a/spec/lib/vainglory_api_spec.rb
+++ b/spec/lib/vainglory_api_spec.rb
@@ -1,10 +1,8 @@
 require 'spec_helper'
 
 describe VaingloryAPI do
-  subject(:klass) { Object.const_get(self.class.top_level_description) }
-
   it 'allows instantiation of a Client' do
-    client = klass.new('API_KEY')
-    expect(client).to be_an_instance_of(klass::Client)
+    client = subject.new('API_KEY')
+    expect(client).to be_an_instance_of(subject::Client)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'webmock/rspec'
 require 'vcr'
 require 'rspec'
+require 'support/klasses'
 require 'simplecov'
 require 'vainglory_api'
 

--- a/spec/support/klasses.rb
+++ b/spec/support/klasses.rb
@@ -1,0 +1,18 @@
+module KlassExampleGroup
+  def self.included(base)
+    base.instance_eval do
+      # Make the class available as `subject` in your examples:
+      subject { Object.const_get(self.class.top_level_description) }
+    end
+  end
+end
+
+
+RSpec.configure do |config|
+  # Tag service specs with `:service` metadata or put them in the spec/services dir
+  config.define_derived_metadata(:file_path => %r{/spec/lib/}) do |metadata|
+    metadata[:type] = :klass
+  end
+
+  config.include KlassExampleGroup, type: :klass
+end


### PR DESCRIPTION
- Specs can use “subject” to refer to described class
- This can probably be improved on in the future